### PR TITLE
Add Magic Number Prefix and Enable NamedPipeServer Auto Reconnect

### DIFF
--- a/Portal.Core/NamedPipe/NamedPipeServer.cs
+++ b/Portal.Core/NamedPipe/NamedPipeServer.cs
@@ -75,17 +75,21 @@ namespace Portal.Core.NamedPipe
             {
                 _receivedBehaviour.ProcessData(_server, _onMessageReceived, _onError);
             }
+            catch (ObjectDisposedException e)
+            {
+                // Ignore ObjectDisposedException
+            }
             catch (Exception e)
             {
                 _onError?.Invoke(e);
             }
             finally
             {
-                if (_isServerRunning && !_disposed && _server.IsConnected)
+                if (_isServerRunning && !_disposed)
                 {
                     try
                     {
-                        // Restart listening for new connection only if the server is still running, not disposed, and connected
+                        // Restart listening for new connection only if the server is still running and not disposed
                         _server.BeginWaitForConnection(new AsyncCallback(ConnectCallback), ar.AsyncState);
                     }
                     catch (Exception e)

--- a/Portal.Gh/Components/Local/NamedPipeReceiverComponent.cs
+++ b/Portal.Gh/Components/Local/NamedPipeReceiverComponent.cs
@@ -24,7 +24,6 @@ namespace Portal.Gh.Components.Local
         public NamedPipeReceiverComponent()
             : base("Pipe Receiver", ">pipe<",
                 "Server that listens for messages sent to a named pipe.\n" +
-                "[4b: int32 size] [data]" +
                 "\n\nNamed Pipes:\n" +
                 "Provides reliable inter-process communication within the same machine, using stream-based data transfer. " +
                 "Named Pipes are highly reliable and suitable for complex data exchanges within a single local machine, " +

--- a/Portal.Gh/Components/Local/NamedPipeSenderComponent.cs
+++ b/Portal.Gh/Components/Local/NamedPipeSenderComponent.cs
@@ -22,7 +22,6 @@ namespace Portal.Gh.Components.Local
         public NamedPipeSenderComponent()
             : base("Pipe Sender", "<pipe>",
                 "Client that sends messages to a named pipe server.\n" +
-                "[4b: int32 size] [data]" +
                 "\n\nNamed Pipes:\n" +
                 "Provides reliable inter-process communication within the same machine, using stream-based data transfer. " +
                 "Named Pipes are highly reliable and suitable for complex data exchanges within a single local machine, " +

--- a/Portal.Gh/Components/Local/SharedMemoryReaderComponent.cs
+++ b/Portal.Gh/Components/Local/SharedMemoryReaderComponent.cs
@@ -23,7 +23,6 @@ namespace Portal.Gh.Components.Local
         public SharedMemoryReaderComponent()
             : base("Shared Memory Reader", ">MMF<",
                 "Reads data once from a shared memory block.\n" +
-                "[16b: byte[] md5] [4b: int32 size] [data]" +
                 "\n\nShared Memory:\n" +
                 "Enables the fastest data exchange possible by allowing direct access to a common " +
                 "memory block between processes on the same machine. This method is unmatched in speed " +

--- a/Portal.Gh/Components/Local/SharedMemoryReaderComponent.cs
+++ b/Portal.Gh/Components/Local/SharedMemoryReaderComponent.cs
@@ -42,7 +42,7 @@ namespace Portal.Gh.Components.Local
 
         protected override void RegisterInputParams(GH_InputParamManager pManager)
         {
-            pManager.AddTextParameter("Memory name", "name", "Unique identifier of a shared memory block", GH_ParamAccess.item);
+            pManager.AddTextParameter("Memory name", "Name", "Unique identifier of a shared memory block", GH_ParamAccess.item);
         }
 
         protected override void RegisterOutputParams(GH_OutputParamManager pManager)

--- a/Portal.Gh/Components/Local/SharedMemoryWriterComponent.cs
+++ b/Portal.Gh/Components/Local/SharedMemoryWriterComponent.cs
@@ -44,7 +44,7 @@ namespace Portal.Gh.Components.Local
 
         protected override void RegisterInputParams(GH_InputParamManager pManager)
         {
-            pManager.AddTextParameter("Memory name", "name", "Unique identifier of a shared memory block", GH_ParamAccess.item);
+            pManager.AddTextParameter("Memory name", "Name", "Unique identifier of a shared memory block", GH_ParamAccess.item);
             pManager.AddParameter(new BytesParam(), "Bytes", "Bytes", "Message data in bytes to write to the shared memory block", GH_ParamAccess.item);
             pManager.AddBooleanParameter("Write", "Write", "Start writing the shared memory block", GH_ParamAccess.item);
         }

--- a/Portal.Gh/Components/Local/SharedMemoryWriterComponent.cs
+++ b/Portal.Gh/Components/Local/SharedMemoryWriterComponent.cs
@@ -24,7 +24,6 @@ namespace Portal.Gh.Components.Local
         public SharedMemoryWriterComponent()
             : base("Shared Memory Writer", "<MMF>",
                 "Writes data to a shared memory block.\n" +
-                "[16b: byte[] md5] [4b: int32 size] [data]" +
                 "\n\nShared Memory:\n" +
                 "Enables the fastest data exchange possible by allowing direct access to a common " +
                 "memory block between processes on the same machine. This method is unmatched in speed " +

--- a/Portal.Gh/Components/Utils/BytesDecoderComponent.cs
+++ b/Portal.Gh/Components/Utils/BytesDecoderComponent.cs
@@ -26,7 +26,7 @@ namespace Portal.Gh.Components.Utils
         }
 
         public override GH_Exposure Exposure => GH_Exposure.tertiary;
-        public override IEnumerable<string> Keywords => new string[] { "fromBytes" };
+        public override IEnumerable<string> Keywords => new string[] { "fromBytes", "decode bytes" };
         protected override Bitmap Icon => Icons.Decode;
         public override Guid ComponentGuid => new Guid("54513217-ed11-4cf7-af69-f0b878432f6c");
 

--- a/Portal.Gh/Components/Utils/BytesDecoderComponent.cs
+++ b/Portal.Gh/Components/Utils/BytesDecoderComponent.cs
@@ -58,6 +58,12 @@ namespace Portal.Gh.Components.Utils
             if (!DA.GetData(0, ref bytesGoo)) return;
             DA.GetData(1, ref password);
 
+            if (!bytesGoo.IsValid)
+            {
+                AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Failed to decode. Input invalid input bytes.");
+                return;
+            }
+
             byte[] rawData = bytesGoo.Value;
             if (rawData == null || rawData.Length == 0) return;
 

--- a/Portal.Gh/Components/Utils/BytesEncoderComponent.cs
+++ b/Portal.Gh/Components/Utils/BytesEncoderComponent.cs
@@ -63,8 +63,7 @@ namespace Portal.Gh.Components.Utils
             bool isEncrypted = !string.IsNullOrEmpty(password);
 
             byte[] payload = Encoding.UTF8.GetBytes(txt);
-            Crc16 crc16 = new Crc16();
-            ushort checksum = crc16.ComputeChecksum(payload);
+            ushort checksum = new Crc16().ComputeChecksum(payload);
 
             // compression
             if (isCompress)

--- a/Portal.Gh/Components/Utils/BytesEncoderComponent.cs
+++ b/Portal.Gh/Components/Utils/BytesEncoderComponent.cs
@@ -26,7 +26,7 @@ namespace Portal.Gh.Components.Utils
         }
 
         public override GH_Exposure Exposure => GH_Exposure.tertiary;
-        public override IEnumerable<string> Keywords => new string[] { "toBytes" };
+        public override IEnumerable<string> Keywords => new string[] { "toBytes", "encode bytes" };
         protected override Bitmap Icon => Icons.Encode;
         public override Guid ComponentGuid => new Guid("3d414461-a9e7-4383-b64a-eeb7af53d8d0");
 


### PR DESCRIPTION
### Change Type
- [x] :sparkles: feat
- [ ] :bug: fix
- [ ] :recycle: refactor
- [ ] :lipstick: style
- [x] :hammer: chore
- [ ] :zap: perf
- [ ] :memo: docs
- [ ] :cd: data

### Description of Change
- **gh**
  - Implement read magic number (6e25112)
  - Minor changes on `mmf` input name (54932e3)
  - Add keyword for encode/decode bytes components (8865dd3)
  - Remove packet structure description (2f5ae8c)
- **core**
  - Add magic number (`0x70, 0x6b` ASCII: `pk`) as prefix (a3f407c)
  - Enable `NamedPipeServer` auto reconnect & update (0526c83)
