### PR TITLE
Fix incorrect fov value & unnessary focalLength calculation

### DIFF
--- a/Portal.Core/DataModel/PCamera.cs
+++ b/Portal.Core/DataModel/PCamera.cs
@@ -10,55 +10,36 @@ namespace Portal.Core.DataModel
     {
         public PVector3D Position { get; set; }
         public PVector3D LookDirection { get; set; }  // This should be a normalized vector
-        public float FieldOfView { get; set; }  // Vertical field of view in degrees
+        public float VerticalFov { get; private set; }  // Vertical field of view in degrees
+        public float HorizontalFov { get; private set; }  // Horizontal field of view in degrees
         public float SensorWidth { get; set; }  // Sensor width in millimeters (mm)
-        public float FocalLength { get; set; }
+        public float FocalLength { get; set; }  // Focal length in millimeters (mm)
         public PVector2Di Resolution { get; set; }  // Resolution of the camera output in pixels
-        
 
-        public PCamera(PVector3D position, PVector3D lookDirection, double lensLength, float sensorWidth, PVector2Di resolution)
+        public PCamera(PVector3D position, PVector3D lookDirection, float focalLength, float sensorWidth, PVector2Di resolution)
         {
             Position = position;
-            LookDirection = lookDirection;
+            LookDirection = lookDirection.Normalize();
+            FocalLength = focalLength;
             SensorWidth = sensorWidth;
             Resolution = resolution;
-            FieldOfView = CalculateFieldOfView(lensLength, sensorWidth);
-            FocalLength = ComputeFocalLength();
-            ValidateDirection();
         }
 
-        private void ValidateDirection()
+        public static double CalculateFov(double angleRadians)
         {
-            if (!LookDirection.IsNormalized())
-            {
-                LookDirection = LookDirection.Normalize();
-            }
+            return (angleRadians * 180.0d) / Math.PI;
         }
 
-        private float ComputeFocalLength()
+        public void SetVerticalFov(float fov)
         {
-            // Convert field of view from degrees to radians for calculation
-            double fieldOfViewRadians = FieldOfView * (Math.PI / 180.0);
-
-            // Calculate focal length using the formula: focalLength = (sensorWidth / 2) / Math.Tan(FOV / 2)
-            double focalLength = (SensorWidth / 2) / Math.Tan(fieldOfViewRadians / 2);
-
-            return (float)focalLength;
+            VerticalFov = fov;
         }
 
-        private float CalculateFieldOfView(double lensLength, double sensorWidth)
+        public void SetHorizontalFov(float fov)
         {
-            // Calculate horizontal FOV using lens length
-            double horizontalFov = 2 * Math.Atan((sensorWidth / 2) / lensLength);
-
-            // Convert horizontal FOV to vertical FOV
-            double aspectRatio = (double)Resolution.X / Resolution.Y;
-            double verticalFov = 2 * Math.Atan(Math.Tan(horizontalFov / 2) / aspectRatio);
-
-            // Convert radians to degrees
-            double verticalFovDegrees = verticalFov * (180.0 / Math.PI);
-
-            return (float)verticalFovDegrees;
+            HorizontalFov = fov;
         }
     }
+
+
 }

--- a/Portal.Gh/Components/Serialization/GetCameraComponent.cs
+++ b/Portal.Gh/Components/Serialization/GetCameraComponent.cs
@@ -9,6 +9,7 @@ using Portal.Core.DataModel;
 using Portal.Gh.Common;
 using Portal.Gh.Params.Json;
 using Rhino;
+using Rhino.DocObjects;
 
 namespace Portal.Gh.Components.Utils
 {
@@ -50,13 +51,31 @@ namespace Portal.Gh.Components.Utils
             RhinoDoc doc = Rhino.RhinoDoc.ActiveDoc;
             if (doc == null) return;
             var viewport = doc.Views.ActiveView.ActiveViewport;
+
+            // Get camera angles
+            // see https://discourse.mcneel.com/t/getting-field-of-view-of-a-viewport-inside-of-rhinocommon/88724/3
+            var vpInfo = new ViewportInfo(viewport);
+            if (!vpInfo.GetCameraAngles(
+                    out double halfDiagonalAngleRadians,
+                    out double halfVerticalAngleRadians,
+                    out double halfHorizontalAngleRadians)
+               )
+            {
+                AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Failed to get camera angles.");
+                return;
+            }
+
             PCamera cam = new PCamera(
                 PTypeConverter.ToPVector3D(viewport.CameraLocation),
                 PTypeConverter.ToPVector3D(viewport.CameraDirection),
-                viewport.Camera35mmLensLength,
+                (float)viewport.Camera35mmLensLength,
                 sensorWidth,
                 new PVector2Di(viewport.Size)
             );
+            double verticalFov = PCamera.CalculateFov(halfVerticalAngleRadians * 2.0);
+            double horizontalFov = PCamera.CalculateFov(halfHorizontalAngleRadians * 2.0);
+            cam.SetVerticalFov((float)verticalFov);
+            cam.SetHorizontalFov((float)horizontalFov);
             
             string camStr = JsonConvert.SerializeObject(cam);
             JsonDict camDict = JsonConvert.DeserializeObject<JsonDict>(camStr);


### PR DESCRIPTION
- Added new vertical fov and horizontal fov property for correct translation from Rhino viewport to Blender
- Corrected FOV calculation, see reference:
  - https://discourse.mcneel.com/t/getting-field-of-view-of-a-viewport-inside-of-rhinocommon/88724/3