### PR TITLE
Introduce Layer Material Serialization and Direct JSON to Byte Conversion

### DIFF
--- a/Portal.Core/DataModel/JsonDict.cs
+++ b/Portal.Core/DataModel/JsonDict.cs
@@ -10,6 +10,11 @@ namespace Portal.Core.DataModel
         {
             return JsonConvert.SerializeObject(this, Formatting.Indented);
         }
+
+        public string ToString(bool indented)
+        {
+            return JsonConvert.SerializeObject(this);
+        }
         public void Dispose()
         {
             Clear();

--- a/Portal.Gh/Components/Local/FileWriterComponent.cs
+++ b/Portal.Gh/Components/Local/FileWriterComponent.cs
@@ -55,15 +55,17 @@ namespace Portal.Gh.Components.Local
             if (!DA.GetData(1, ref path)) return;
             if (!DA.GetData(2, ref write)) return;
 
-            if (write)
+            if (!write)
             {
-                ushort checksum = Packet.Deserialize(data.Value).Header.Checksum;
-                if (_lastChecksum != 0 && _lastChecksum  == checksum) return; // // Skip if the message is the same
-
-                System.IO.File.WriteAllBytes(path, data.Value);
-                _lastChecksum = checksum;
-                Message = "Written";
+                _lastChecksum = 0; // Reset checksum
+                return;
             }
+            ushort checksum = Packet.Deserialize(data.Value).Header.Checksum;
+            if (_lastChecksum != 0 && _lastChecksum  == checksum) return; // // Skip if the message is the same
+
+            System.IO.File.WriteAllBytes(path, data.Value);
+            _lastChecksum = checksum;
+            Message = "Written";
         }
     }
 }

--- a/Portal.Gh/Components/Local/NamedPipeSenderComponent.cs
+++ b/Portal.Gh/Components/Local/NamedPipeSenderComponent.cs
@@ -66,7 +66,11 @@ namespace Portal.Gh.Components.Local
 
             string serverName = "."; // Local machine
             
-            if (!send) return;
+            if (!send)
+            {
+                _lastChecksum = 0; // Reset checksum
+                return;
+            }
             ushort checksum = Packet.Deserialize(message.Value).Header.Checksum;
             if (checksum != 0 && checksum == _lastChecksum) return; // Skip if the message is the same
 

--- a/Portal.Gh/Components/Local/SharedMemoryWriterComponent.cs
+++ b/Portal.Gh/Components/Local/SharedMemoryWriterComponent.cs
@@ -87,7 +87,11 @@ namespace Portal.Gh.Components.Local
             if (!DA.GetData(1, ref message)) return;
             if (!DA.GetData(2, ref write)) return;
 
-            if (!write) return;
+            if (!write)
+            {
+                _lastChecksum = 0; // Reset checksum
+                return;
+            }
             ushort checksum = Packet.Deserialize(message.Value).Header.Checksum;
             if (checksum != 0 && checksum == _lastChecksum) return; // Skip if the message is the same
 

--- a/Portal.Gh/Components/Remote/UdpSenderComponent.cs
+++ b/Portal.Gh/Components/Remote/UdpSenderComponent.cs
@@ -82,7 +82,11 @@ namespace Portal.Gh.Components.Remote
             }
 
 
-            if (!send) return;
+            if (!send)
+            {
+                _lastChecksum = 0; // Reset checksum
+                return;
+            }
             try
             {
                 ushort checksum = Packet.Deserialize(message.Value).Header.Checksum;

--- a/Portal.Gh/Components/Remote/WebSocketClientComponent.cs
+++ b/Portal.Gh/Components/Remote/WebSocketClientComponent.cs
@@ -111,14 +111,20 @@ namespace Portal.Gh.Components.Remote
             string uri = $"ws://{hostIp}:{port}{route}";
             Message = uri;
 
+            if (!connect)
+            {
+                _lastChecksum = 0; // Reset checksum
+                return;
+            }
+
             ushort checksum = Packet.Deserialize(msg.Value).Header.Checksum;
             if (checksum != 0 && checksum == _lastChecksum) return; // Skip if the message is the same
 
-            if (connect && !_socketClient.IsConnected)
+            if (!_socketClient.IsConnected)
             {
                 _socketClient.Connect(uri);
             }
-            else if (!connect && _socketClient.IsConnected)
+            else if (_socketClient.IsConnected)
             {
                 _socketClient.Disconnect();
             }

--- a/Portal.Gh/Params/Bytes/BytesGoo.cs
+++ b/Portal.Gh/Params/Bytes/BytesGoo.cs
@@ -12,6 +12,7 @@ using Portal.Core.Encryption;
 using Portal.Core.Utils;
 using Newtonsoft.Json.Linq;
 using Portal.Core.Binary;
+using Portal.Gh.Params.Json;
 
 namespace Portal.Gh.Params.Bytes
 {
@@ -128,6 +129,23 @@ namespace Portal.Gh.Params.Bytes
                     _headerIsValid = false;
                 }
                 
+                return true;
+            }
+
+            if (source is JsonDictGoo jsonGoo)
+            {
+                var json = jsonGoo.Value;
+                try
+                {
+                    byte[] rawBytes = Encoding.UTF8.GetBytes(json.ToString(true));
+                    Packet packet = new Packet(rawBytes, false, false, new Crc16().ComputeChecksum(rawBytes));
+                    Value = packet.Serialize();
+                    _headerIsValid = true;
+                }
+                catch (Exception e)
+                {
+                    _headerIsValid = false;
+                }
                 return true;
             }
 


### PR DESCRIPTION
### Change Type
- [x] :sparkles: feat
- [x] :bug: fix
- [ ] :recycle: refactor
- [ ] :lipstick: style
- [ ] :hammer: chore
- [ ] :zap: perf
- [ ] :memo: docs
- [ ] :cd: data

### Description of Change
- **feat**
  - Serialize layer material if it exists (3bcd8c6)
  - JSON object can now directly convert to `byte` (201bbfb)
- **fix**
  - Allow resend message after `send` is toggled off (9c2ed37)
- **docs**
  - Update readme.md (b93be23)

### Note
This release introduces the ability to serialize layer-level materials when they exist, enhancing the data handling capabilities. Additionally, JSON objects now support direct conversion to `byte`, streamlining data processing. A fix has been applied to allow message resending after the `send` option is toggled off, ensuring better communication flow.