### PR TITLE
Assign location as center of rectangular light

### DIFF
--- a/Portal.Core/DataModel/Coordinates3D.cs
+++ b/Portal.Core/DataModel/Coordinates3D.cs
@@ -51,6 +51,36 @@ namespace Portal.Core.DataModel
         {
             return Math.Abs(Math.Sqrt(X * X + Y * Y + Z * Z) - 1) < tolerance;
         }
+
+        public static PVector3D CrossProduct(PVector3D a, PVector3D b)
+        {
+            return new PVector3D(a.Y * b.Z - a.Z * b.Y,
+                a.Z * b.X - a.X * b.Z,
+                a.X * b.Y - a.Y * b.X);
+        }
+
+        public static double DotProduct(PVector3D a, PVector3D b)
+        {
+            return a.X * b.X + a.Y * b.Y + a.Z * b.Z;
+        }
+
+        public static double AngleBetween(PVector3D a, PVector3D b)
+        {
+            return Math.Acos(DotProduct(a, b) / (a.Magnitude() * b.Magnitude()));
+        }
+
+        public double Magnitude()
+        {
+            // Pythagorean theorem
+            // a^2 + b^2 = c^2
+            return Math.Sqrt(X * X + Y * Y + Z * Z);
+        }
+
+        // operators for vector math
+        public static PVector3D operator +(PVector3D a, PVector3D b) => new PVector3D(a.X + b.X, a.Y + b.Y, a.Z + b.Z);
+        public static PVector3D operator -(PVector3D a, PVector3D b) => new PVector3D(a.X - b.X, a.Y - b.Y, a.Z - b.Z);
+        public static PVector3D operator *(PVector3D a, double b) => new PVector3D(a.X * b, a.Y * b, a.Z * b);
+        public static PVector3D operator /(PVector3D a, double b) => new PVector3D(a.X / b, a.Y / b, a.Z / b);
     }
 
     public class PVector3Df : Coordinates3D<float>
@@ -85,6 +115,36 @@ namespace Portal.Core.DataModel
         {
             return Math.Abs(Math.Sqrt(X * X + Y * Y + Z * Z) - 1) < tolerance;
         }
+
+        public static PVector3Df CrossProduct(PVector3Df a, PVector3Df b)
+        {
+            return new PVector3Df(a.Y * b.Z - a.Z * b.Y,
+                a.Z * b.X - a.X * b.Z,
+                a.X * b.Y - a.Y * b.X);
+        }
+
+        public static double DotProduct(PVector3Df a, PVector3Df b)
+        {
+            return a.X * b.X + a.Y * b.Y + a.Z * b.Z;
+        }
+
+        public static double AngleBetween(PVector3Df a, PVector3Df b)
+        {
+            return Math.Acos(DotProduct(a, b) / (a.Magnitude() * b.Magnitude()));
+        }
+
+        public double Magnitude()
+        {
+            // Pythagorean theorem
+            // a^2 + b^2 = c^2
+            return Math.Sqrt(X * X + Y * Y + Z * Z);
+        }
+
+        // operators for vector math
+        public static PVector3Df operator +(PVector3Df a, PVector3Df b) => new PVector3Df(a.X + b.X, a.Y + b.Y, a.Z + b.Z);
+        public static PVector3Df operator -(PVector3Df a, PVector3Df b) => new PVector3Df(a.X - b.X, a.Y - b.Y, a.Z - b.Z);
+        public static PVector3Df operator *(PVector3Df a, double b) => new PVector3Df(a.X * (float)b, a.Y * (float)b, a.Z * (float)b);
+        public static PVector3Df operator /(PVector3Df a, double b) => new PVector3Df(a.X / (float)b, a.Y / (float)b, a.Z / (float)b);
     }
 
     

--- a/Portal.Core/DataModel/PLight.cs
+++ b/Portal.Core/DataModel/PLight.cs
@@ -60,21 +60,26 @@ namespace Portal.Core.DataModel
     {
         public PVector3D Length { get; private set; }
         public PVector3D Width { get; private set; }
+        public PVector3D Perpendicular { get; private set; }
 
         public PRectangularLight(string name, Color diffuseColor, PAttenuation attenuation, PVector3D attenuationVector,
-            PVector3D position, PVector3D direction, double intensity, double shadowIntensity,
+            PVector3D location, PVector3D perpendicular, PVector3D direction, double intensity, double shadowIntensity,
             PVector3D length, PVector3D width) : base(PLightType.Rectangular)
         {
             Name = name;
             Color = new PColor(diffuseColor).ToHex();
             Attenuation = attenuation.ToString();
             AttenuationVector = attenuationVector;
-            Position = position;
+            Perpendicular = perpendicular;
             Direction = direction;
             Intensity = intensity;
             ShadowIntensity = shadowIntensity;
             Length = length;
             Width = width;
+
+            // since rectangular lights location in Rhino is at the corner of the rectangle, we need to calculate the center
+            PVector3D center = location + (length * 0.5) + (width * 0.5);
+            Position = center;
         }
     }
 

--- a/Portal.Gh/Components/Serialization/GetLightComponent.cs
+++ b/Portal.Gh/Components/Serialization/GetLightComponent.cs
@@ -110,6 +110,7 @@ namespace Portal.Gh.Components.Serialization
                     return new PRectangularLight(l.Name, l.Diffuse, (PAttenuation)l.AttenuationType,
                         PTypeConverter.ToPVector3D(l.AttenuationVector),
                         PTypeConverter.ToPVector3D(l.Location),
+                        PTypeConverter.ToPVector3D(l.PerpendicularDirection),
                         PTypeConverter.ToPVector3D(l.Direction), l.Intensity, l.ShadowIntensity,
                         PTypeConverter.ToPVector3D(l.Length),
                         PTypeConverter.ToPVector3D(l.Width));


### PR DESCRIPTION
By default rhino assign the rectangular's location at the corner, this pull request get the center.