### PR TITLE
feat: change coords to list for compactness

### DIFF
--- a/Portal.Core/DataModel/Coordinates2D.cs
+++ b/Portal.Core/DataModel/Coordinates2D.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
@@ -7,6 +8,62 @@ using System.Threading.Tasks;
 
 namespace Portal.Core.DataModel
 {
+    public class Coordinates2DConverter: JsonConverter
+    {
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            dynamic coordinates = value;
+            if (coordinates != null) {
+                writer.WriteStartArray();
+                writer.WriteValue(coordinates.X);
+                writer.WriteValue(coordinates.Y);
+                writer.WriteEndArray();
+            }
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            // Ensure we're reading an array
+            if (reader.TokenType != JsonToken.StartArray)
+            {
+                throw new JsonSerializationException($"Unexpected token parsing Coordinates2D. Expected StartArray, got {reader.TokenType}.");
+            }
+
+            if (objectType.BaseType == null)
+            {
+                throw new JsonSerializationException($"Unexpected token parsing Coordinates2D. BaseType is null.");
+            }
+
+            reader.Read(); // Move to the first element in the array
+
+            // Get the type parameter T (float or double)
+            Type tType = objectType.BaseType.GetGenericArguments()[0];
+
+            // Deserialize each coordinate as the correct type
+            object x = serializer.Deserialize(reader, tType);
+            reader.Read(); // Move to the next element
+            object y = serializer.Deserialize(reader, tType);
+            reader.Read(); // Move to the EndArray token
+
+            if (reader.TokenType != JsonToken.EndArray)
+            {
+                throw new JsonSerializationException($"Unexpected token parsing Coordinates2D. Expected EndArray, got {reader.TokenType}.");
+            }
+
+            // Create an instance of the object using the correct constructor
+            return Activator.CreateInstance(objectType, x, y);
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType.IsSubclassOf(typeof(Coordinates2D<>));
+        }
+
+        public override bool CanRead => true;
+        public override bool CanWrite => true;
+    }
+
+    [JsonConverter(typeof(Coordinates2DConverter))]
     public abstract class Coordinates2D<T>
     {
         public T X { get; set; }

--- a/Portal.Core/DataModel/JsonArray.cs
+++ b/Portal.Core/DataModel/JsonArray.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace Portal.Core.DataModel
+{
+    public class JsonArray: List<object>, IDisposable
+    {
+        public override string ToString()
+        {
+            return JsonConvert.SerializeObject(this, Formatting.Indented);
+        }
+
+        public string ToString(bool indented)
+        {
+            return JsonConvert.SerializeObject(this);
+        }
+
+        public void Dispose()
+        {
+            Clear();
+        }
+    }
+}

--- a/Portal.Core/Portal.Core.csproj
+++ b/Portal.Core/Portal.Core.csproj
@@ -65,6 +65,7 @@
     <Compile Include="DataModel\Coordinates2D.cs" />
     <Compile Include="DataModel\Coordinates3D.cs" />
     <Compile Include="Binary\Packet.cs" />
+    <Compile Include="DataModel\JsonArray.cs" />
     <Compile Include="DataModel\JsonDict.cs" />
     <Compile Include="DataModel\Payload.cs" />
     <Compile Include="DataModel\PCamera.cs" />

--- a/Portal.Gh/Components/Serialization/SerializeGeometryComponent.cs
+++ b/Portal.Gh/Components/Serialization/SerializeGeometryComponent.cs
@@ -15,6 +15,7 @@ using Rhino.DocObjects;
 using Point = Rhino.Geometry.Point;
 using Grasshopper.Kernel.Types;
 using Eto.Drawing;
+using Newtonsoft.Json.Linq;
 using Rhino;
 using Bitmap = System.Drawing.Bitmap;
 
@@ -96,7 +97,7 @@ namespace Portal.Gh.Components.Serialization
         private Payload SerializeGeometry(Point3d geo, JsonDict meta)
         {
             string jsonString = JsonConvert.SerializeObject(new PVector3D(geo.X, geo.Y, geo.Z));
-            JsonDict dict = JsonConvert.DeserializeObject<JsonDict>(jsonString);
+            JsonArray dict = JsonConvert.DeserializeObject<JsonArray>(jsonString);
             return new Payload(dict, meta);
         }
 


### PR DESCRIPTION
- Coordinates now represented as a list instead of a `dict`
- This change makes the data more compact

| **Before** | **After** |
| --- | --- |
| `{"X": 1, "Y": 2, "Z": 3}` | `[1,2,3]` |