### PR TITLE
chore: improve byte length accuracy

### DIFF
--- a/Portal.Gh/Params/Bytes/BytesGoo.cs
+++ b/Portal.Gh/Params/Bytes/BytesGoo.cs
@@ -104,7 +104,7 @@ namespace Portal.Gh.Params.Bytes
             {
                 if (length >= threshold.Key)
                 {
-                    return $"{length / threshold.Key} {threshold.Value}";
+                    return $"{(float)length / threshold.Key} {threshold.Value}";
                 }
             }
 


### PR DESCRIPTION
- Calculate byte length in float instead of int